### PR TITLE
Huge rewrite to fix role issues and cloak issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- Fixed even more issues with a player's weapons still being visible to other players
+    - This had to do with the weapon's `SWEP:Think` not being called properly at all times
 - Fixed a player's role being forcibly set when being confirmed
 - Fixed weapon think code not being called on clients for listen servers
 - Fixed several hooks not being registered properly by ensuring they are registered after the gamemode has loaded
+    - `TTT2` is not a valid global until *after* the gamemode has loaded (post `GM:Initialize`)
 
 ### Added
 - Added `ttt_deadringer_cloak_transparency`
@@ -21,11 +24,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - You can set this to `1` if you want to be able to see the player's name when hovering over them still
 - Added `ttt_deadringer_damage_threshold`
     - Previously the threshold to trigger the Dead Ringer was 2 damage, this is now a setting you can change
+- The addon will now more closely mimic the Death Faker addon
+    - While cloaked, if your body is discovered, the scoreboard will show you as confirmed dead
+    - This will use your `ttt_deadringer_corpse_confirm` setting
+        - If it is 0, you will just show as confirmed dead and no role
+        - If it is 1, you will be shown as confirmed dead with your real role
+        - If it is 2, you will be shown as confirmed dead as an innocent
+    - This does NOT apply to public roles like Detective, your real role will always show
+    - When the cloak ends, your death will automatically be unconfirmed when the corpse disappears
+- Added some help test for TTT and TTT2 do show what the primary and secondary buttons do
 
 ### Changed
 - Renamed `ttt_deadringer_chargetime` to `ttt_deadringer_cloak_cooldown` to be more consistent with the new transparency convar
 - Renamed `ttt_deadringer_cloaktime` to `ttt_deadringer_cloak_duration` to be more consistent with other convars
 - Renamed `ttt_deadringer_cloaktime_reuse` to `ttt_deadringer_cloak_reuse` to be more consistent with other convars
+- Changed the weapon to use NW variables instead of NW2 variables
+    - This may be temporary, NW2 variables are strongly preferred but I want to see if the addon is stable first
 
 ## [2.2.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Fixed a player's role being forcibly set when being confirmed
+- Fixed weapon think code not being called on clients for listen servers
+- Fixed several hooks not being registered properly by ensuring they are registered after the gamemode has loaded
+
+### Added
+- Added `ttt_deadringer_cloak_transparency`
+    - You can change how transparent the Dead Ringer cloak is for balance reasons (0.0 - 1.0)
+    - By default it is completely transparent (0.0), if you want some subtle balance I recommend a setting of 0.05
+- Added `ttt_deadringer_cloak_targetid`
+    - By default the target id of the player will be hidden (setting of `0`) so you can't immediately follow where they are
+    - You can set this to `1` if you want to be able to see the player's name when hovering over them still
+- Added `ttt_deadringer_damage_threshold`
+    - Previously the threshold to trigger the Dead Ringer was 2 damage, this is now a setting you can change
+
+### Changed
+- Renamed `ttt_deadringer_chargetime` to `ttt_deadringer_cloak_cooldown` to be more consistent with the new transparency convar
+- Renamed `ttt_deadringer_cloaktime` to `ttt_deadringer_cloak_duration` to be more consistent with other convars
+- Renamed `ttt_deadringer_cloaktime_reuse` to `ttt_deadringer_cloak_reuse` to be more consistent with other convars
+
 ## [2.2.0]
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -12,12 +12,15 @@ Includes an individual shop icon.
 
 ## ConVars
 
-- ttt_deadringer_chargetime (def: 20) - Time it takes to recharge the Dead Ringer.
-- ttt_deadringer_cloaktime (def: 7) - Time that the Dead Ringer will cloak you for.
+- ttt_deadringer_cloak_cooldown (def: 20) - Time it takes to recharge the Dead Ringer.
+- ttt_deadringer_cloak_duration (def: 7) - Time that the Dead Ringer will cloak you for.
+- ttt_deadringer_cloak_reuse (def: 0) - Whether or not the Dead Ringer will convert unused cloak time into charge time.
+- ttt_deadringer_cloak_transparency (def: 0.0) - Transparency of the Dead Ringer cloak. (0.0 = invisible, 1.0 = visible)
+- ttt_deadringer_cloak_targetid (def: 0) - Whether or not the Dead Ringer will show the target ID while cloaked.
+- ttt_deadringer_damage_threshold (def: 2) - Threshold to trigger the Dead Ringer. The threshold is a flat value, not a percentage.
 - ttt_deadringer_damage_reduction (def: 0.65) - Damage reduction while cloaked.
 - ttt_deadringer_damage_reduction_time (def: 3) - Damage reduction time while cloaked.
 - ttt_deadringer_damage_reduction_initial (def: 0.75) - Percentage of damage reduction for the initial hit which triggers the Dead Ringer. (0.75 = 75%)
-- ttt_deadringer_cloaktime_reuse (def: 0) - Whether or not the Dead Ringer will convert unused cloak time into charge time.
 - ttt_deadringer_corpse_mode (def: 0) - Whether or not the Dead Ringer will show a fake role, real role, or spoofed innocent role.
 - ttt_deadringer_corpse_confirm (def: 0) - Whether or not the Dead Ringer will confirm the death of the player on the corpse.
 

--- a/lua/autorun/ttt_deadringer.lua
+++ b/lua/autorun/ttt_deadringer.lua
@@ -40,15 +40,15 @@ end
 
 -- ConVars
 
-local flags = {FCVAR_SERVER_CAN_EXECUTE, FCVAR_ARCHIVE, FCVAR_REPLICATED}
-if TTT2 then
-	table.insert(flags, FCVAR_NOTIFY)
-end
+local flags = {FCVAR_SERVER_CAN_EXECUTE, FCVAR_ARCHIVE, FCVAR_REPLICATED, FCVAR_NOTIFY}
 
-CreateConVar('ttt_deadringer_chargetime', '20', flags, 'Time it takes to recharge the Dead Ringer.')
-CreateConVar('ttt_deadringer_cloaktime', '7', flags, 'Time that the Dead Ringer will cloak you for.')
-CreateConVar('ttt_deadringer_cloaktime_reuse', '0', flags, 'Whether or not the Dead Ringer will convert unused cloak time into charge time.')
+CreateConVar('ttt_deadringer_cloak_cooldown', '20', flags, 'Time it takes to recharge the Dead Ringer.')
+CreateConVar('ttt_deadringer_cloak_duration', '7', flags, 'Time that the Dead Ringer will cloak you for.')
+CreateConVar('ttt_deadringer_cloak_reuse', '0', flags, 'Whether or not the Dead Ringer will convert unused cloak time into charge time.')
+CreateConVar('ttt_deadringer_cloak_transparency', '0.0', flags, 'Transparency of the Dead Ringer cloak. (0.0 = invisible, 1.0 = visible)')
+CreateConVar('ttt_deadringer_cloak_targetid', '0', flags, 'Whether or not the Dead Ringer will show the target ID while cloaked.')
 
+CreateConVar('ttt_deadringer_damage_threshold', '2', flags, 'Threshold to trigger the Dead Ringer. The threshold is a flat value, not a percentage')
 CreateConVar('ttt_deadringer_damage_reduction', '0.65', flags, 'Damage reduction while cloaked.')
 CreateConVar('ttt_deadringer_damage_reduction_time', '3', flags, 'Damage reduction time while cloaked. (1.0 = 1 second of damage reduction)')
 CreateConVar('ttt_deadringer_damage_reduction_initial', '0.75', flags, 'Percentage of damage reduction for the initial hit which triggers the Dead Ringer. (0.75 = 75%)')
@@ -63,12 +63,15 @@ hook.Add('AddToolMenuCategories', 'DeadringerAddToolMenuCategories', function()
 end)
 
 local DEADRINGER_DEFAULTS = {
-	ttt_deadringer_chargetime = 20,
-	ttt_deadringer_cloaktime = 7,
+	ttt_deadringer_cloak_cooldown = 20,
+	ttt_deadringer_cloak_duration = 7,
+	ttt_deadringer_cloak_reuse = 0,
+	ttt_deadringer_cloak_transparency = 0,
+	ttt_deadringer_cloak_targetid = 0,
 	ttt_deadringer_damage_reduction = 0.65,
 	ttt_deadringer_damage_reduction_time = 3,
 	ttt_deadringer_damage_reduction_initial = 0.75,
-	ttt_deadringer_cloaktime_reuse = 0,
+	ttt_deadringer_damage_threshold = 2,
 	ttt_deadringer_corpse_mode = 0,
 	ttt_deadringer_corpse_confirm = 0
 }
@@ -81,18 +84,27 @@ hook.Add('PopulateToolMenu', 'DeadringerPopulateToolMenu', function()
 
 		panel:Help('General Settings')
 
-		panel:NumSlider('Charge Time', 'ttt_deadringer_chargetime', 1, 60, 0)
+		panel:NumSlider('Charge Time', 'ttt_deadringer_cloak_cooldown', 1, 60, 0)
 		panel:ControlHelp('Time it takes to recharge the Dead Ringer.')
 
 		panel:Help('Cloak Settings')
 
-		panel:NumSlider('Cloak Time', 'ttt_deadringer_cloaktime', 1, 60, 0)
+		panel:NumSlider('Cloak Time', 'ttt_deadringer_cloak_duration', 1, 60, 0)
 		panel:ControlHelp('Time that the Dead Ringer will cloak you for.')
 
-		panel:CheckBox('Cloak Time Reuse', 'ttt_deadringer_cloaktime_reuse')
+		panel:CheckBox('Cloak Time Reuse', 'ttt_deadringer_cloak_reuse')
 		panel:ControlHelp('Whether or not the Dead Ringer will convert unused cloak time into charge time.')
 
+		panel:NumSlider('Cloak Transparency', 'ttt_deadringer_cloak_transparency', 0, 1, 2)
+		panel:ControlHelp('Transparency of the Dead Ringer cloak. (0.0 = invisible, 1.0 = visible)')
+
+		panel:CheckBox('Cloak Target ID', 'ttt_deadringer_cloak_targetid')
+		panel:ControlHelp('Whether or not the Dead Ringer will show the target ID while cloaked.')
+
 		panel:Help('Damage Reduction Settings')
+
+		panel:NumSlider('Damage Threshold', 'ttt_deadringer_damage_threshold', 0, 100, 0)
+		panel:ControlHelp('The threshold is a flat value, not a percentage')
 
 		panel:NumSlider('Damage Reduction', 'ttt_deadringer_damage_reduction', 0, 1, 2)
 		panel:ControlHelp('Damage reduction while cloaked.')
@@ -113,43 +125,6 @@ hook.Add('PopulateToolMenu', 'DeadringerPopulateToolMenu', function()
 	end)
 end)
 
--- TTT/2 Compatibility
-
-if CLIENT then
-	hook.Add('InitPostEntity', 'DeadringerInitPostEntity', function()
-		if LANG == nil then return end
-
-		local lang = TTT2 and 'en' or 'english'
-
-		LANG.AddToLanguage(lang, 'deadringer_name', 'Dead Ringer')
-		LANG.AddToLanguage(lang, 'deadringer_desc', 'A watch that feigns your death when you take damage. You will be cloaked for a short time and your attacker will be fooled.')
-
-		LANG.AddToLanguage(lang, 'label_ttt_deadringer_chargetime', 'Charge Time')
-		LANG.AddToLanguage(lang, 'help_ttt_deadringer_chargetime', 'Time it takes to recharge the Dead Ringer.')
-
-		LANG.AddToLanguage(lang, 'label_ttt_deadringer_cloaktime', 'Cloak Time')
-		LANG.AddToLanguage(lang, 'help_ttt_deadringer_cloaktime', 'Whether or not the Dead Ringer will convert unused cloak time into charge time.')
-
-		LANG.AddToLanguage(lang, 'label_ttt_deadringer_damage_reduction', 'Damage Reduction')
-		LANG.AddToLanguage(lang, 'help_ttt_deadringer_damage_reduction', 'Damage reduction while cloaked.')
-
-		LANG.AddToLanguage(lang, 'label_ttt_deadringer_damage_reduction_time', 'Damage Reduction Time')
-		LANG.AddToLanguage(lang, 'help_ttt_deadringer_damage_reduction_time', 'Damage reduction time while cloaked. (1.0 = 1 second of damage reduction)')
-
-		LANG.AddToLanguage(lang, 'label_ttt_deadringer_damage_reduction_initial', 'Damage Reduction Initial')
-		LANG.AddToLanguage(lang, 'help_ttt_deadringer_damage_reduction_initial', 'Percentage of damage reduction for the initial hit which triggers the Dead Ringer. (0.75 = 75%)')
-
-		LANG.AddToLanguage(lang, 'label_ttt_deadringer_cloaktime_reuse', 'Cloak Time Reuse')
-		LANG.AddToLanguage(lang, 'help_ttt_deadringer_cloaktime_reuse', 'Whether or not the Dead Ringer will convert unused cloak time into charge time.')
-
-		LANG.AddToLanguage(lang, 'label_ttt_deadringer_corpse_mode', 'Role Mode')
-		LANG.AddToLanguage(lang, 'help_ttt_deadringer_corpse_mode', 'Whether or not the Dead Ringer will show the real role of the player on the corpse. (0 = fake, 1 = real, 2 = innocent)')
-
-		LANG.AddToLanguage(lang, 'label_ttt_deadringer_corpse_confirm', 'Confirm Death')
-		LANG.AddToLanguage(lang, 'help_ttt_deadringer_corpse_confirm', 'Whether or not the Dead Ringer will confirm the death of the player on the corpse.')
-	end)
-end
-
 hook.Add('Initialize', 'DeadringerInitialize', function()
 	-- TTT2 Compatibility
 
@@ -163,7 +138,7 @@ hook.Add('Initialize', 'DeadringerInitialize', function()
 			hud = Material('vgui/ttt/hud_icon_deadringer.png'),
 			type = 'good',
 			DrawInfo = function()
-				local status = LocalPlayer():GetNW2Int('DRStatus', 0)
+				local status = LocalPlayer():GetNWInt('DRStatus', 0)
 
 				return status == 1 and 'on' or 'off'
 			end
@@ -174,96 +149,5 @@ hook.Add('Initialize', 'DeadringerInitialize', function()
 			type = 'bad'
 		})
 		return
-	end
-
-	-- TTT ULX Compatibility
-	if CLIENT and not TTT2 then
-		hook.Add('TTTUlxModifyAddonSettings', 'DeadringerTTTUlxModifyAddonSettings', function(panel)
-			local root = xlib.makelistlayout{w = 415, h = 318, parent = xgui.null}
-
-			-- Basic Settings
-			local basicCategory = vgui.Create('DCollapsibleCategory', root)
-			basicCategory:SetSize(390, 50)
-			basicCategory:SetExpanded(1)
-			basicCategory:SetLabel('Basic Settings')
-
-			local basicList = vgui.Create('DPanelList', basicCategory)
-			basicList:SetPos(5, 25)
-			basicList:SetSize(390, 150)
-			basicList:SetSpacing(5)
-
-			local chargeTime = xlib.makeslider{label = 'Charge Time (def. 10)', repconvar = 'rep_ttt_deadringer_chargetime', min = 1, max = 60, decimal = 0, parent = basicList}
-			basicList:AddItem(chargeTime)
-
-			-- Cloak Settings
-			local cloakCategory = vgui.Create('DCollapsibleCategory', root)
-			cloakCategory:SetSize(390, 50)
-			cloakCategory:SetExpanded(1)
-			cloakCategory:SetLabel('Cloak Settings')
-
-			local cloakList = vgui.Create('DPanelList', cloakCategory)
-			cloakList:SetPos(5, 25)
-			cloakList:SetSize(390, 150)
-			cloakList:SetSpacing(5)
-
-			local cloakTime = xlib.makeslider{label = 'Cloak Time (def. 6)', repconvar = 'rep_ttt_deadringer_cloaktime', min = 1, max = 60, decimal = 0, parent = basicList}
-			cloakList:AddItem(cloakTime)
-
-			local cloakTimeReuse = xlib.makecheckbox{label = 'Cloak Time Reuse (def. 1)', repconvar = 'rep_ttt_deadringer_cloaktime_reuse', parent = cloakList}
-			cloakList:AddItem(cloakTimeReuse)
-
-			-- Damage Reduction Settings
-			local damageCategory = vgui.Create('DCollapsibleCategory', root)
-			damageCategory:SetSize(390, 50)
-			damageCategory:SetExpanded(1)
-			damageCategory:SetLabel('Damage Reduction Settings')
-
-			local damageList = vgui.Create('DPanelList', damageCategory)
-			damageList:SetPos(5, 25)
-			damageList:SetSize(390, 150)
-			damageList:SetSpacing(5)
-
-			local damageReduction = xlib.makeslider{label = 'Damage Reduction (def. 0.65)', repconvar = 'rep_ttt_deadringer_damage_reduction', min = 0, max = 1, decimal = 2, parent = damageList}
-			damageList:AddItem(damageReduction)
-
-			local damageReductionTime = xlib.makeslider{label = 'Damage Reduction Time (def. 3)', repconvar = 'rep_ttt_deadringer_damage_reduction_time', min = 0, max = 60, decimal = 1, parent = damageList}
-			damageList:AddItem(damageReductionTime)
-
-			local damageReductionInitial = xlib.makeslider{label = 'Damage Reduction Initial (def. 0.75)', repconvar = 'rep_ttt_deadringer_damage_reduction_initial', min = 0, max = 1, decimal = 2, parent = damageList}
-			damageList:AddItem(damageReductionInitial)
-
-			-- Corpse Settings
-			local corpseCategory = vgui.Create('DCollapsibleCategory', root)
-			corpseCategory:SetSize(390, 50)
-			corpseCategory:SetExpanded(1)
-			corpseCategory:SetLabel('Corpse Settings')
-
-			local corpseList = vgui.Create('DPanelList', corpseCategory)
-			corpseList:SetPos(5, 25)
-			corpseList:SetSize(390, 150)
-			corpseList:SetSpacing(5)
-
-			local corpseRole = xlib.makeslider{label = 'Role Mode (def. 0)', repconvar = 'rep_ttt_deadringer_corpse_mode', min = 0, max = 2, decimal = 0, parent = corpseList}
-			corpseList:AddItem(corpseRole)
-
-			local corpseConfirm = xlib.makecheckbox{label = 'Confirm Death (def. 1)', repconvar = 'rep_ttt_deadringer_corpse_confirm', parent = corpseList}
-			corpseList:AddItem(corpseConfirm)
-
-			xgui.hookEvent('onProcessModules', nil, root.processModules)
-			xgui.addSubModule('Dead Ringer', root, nil, panel)
-		end)
-	end
-
-	if SERVER and not TTT2 then
-		hook.Add('TTTUlxInitCustomCVar', 'DeadringerTTTUlxInitCustomCVar', function(name)
-			ULib.replicatedWritableCvar('ttt_deadringer_chargetime', 'rep_ttt_deadringer_chargetime', GetConVar('ttt_deadringer_chargetime'):GetFloat(), true, false, name)
-			ULib.replicatedWritableCvar('ttt_deadringer_cloaktime', 'rep_ttt_deadringer_cloaktime', GetConVar('ttt_deadringer_cloaktime'):GetFloat(), true, false, name)
-			ULib.replicatedWritableCvar('ttt_deadringer_damage_reduction', 'rep_ttt_deadringer_damage_reduction', GetConVar('ttt_deadringer_damage_reduction'):GetFloat(), true, false, name)
-			ULib.replicatedWritableCvar('ttt_deadringer_damage_reduction_time', 'rep_ttt_deadringer_damage_reduction_time', GetConVar('ttt_deadringer_damage_reduction_time'):GetFloat(), true, false, name)
-			ULib.replicatedWritableCvar('ttt_deadringer_damage_reduction_initial', 'rep_ttt_deadringer_damage_reduction_initial', GetConVar('ttt_deadringer_damage_reduction_initial'):GetFloat(), true, false, name)
-			ULib.replicatedWritableCvar('ttt_deadringer_cloaktime_reuse', 'rep_ttt_deadringer_cloaktime_reuse', GetConVar('ttt_deadringer_cloaktime_reuse'):GetBool(), true, false, name)
-			ULib.replicatedWritableCvar('ttt_deadringer_corpse_mode', 'rep_ttt_deadringer_corpse_mode', GetConVar('ttt_deadringer_corpse_mode'):GetInt(), true, false, name)
-			ULib.replicatedWritableCvar('ttt_deadringer_corpse_confirm', 'rep_ttt_deadringer_corpse_confirm', GetConVar('ttt_deadringer_corpse_confirm'):GetBool(), true, false, name)
-		end)
 	end
 end)

--- a/lua/autorun/ttt_deadringer_hooks.lua
+++ b/lua/autorun/ttt_deadringer_hooks.lua
@@ -1,0 +1,89 @@
+AddCSLuaFile()
+
+hook.Add('Initialize', 'DR.Initialize.Hooks', function()
+    if SERVER and TTT2 then
+        hook.Add('TTT2ConfirmPlayer', 'DR.TTT2ConfirmPlayer', function(victim, ply, ragdoll)
+            if not IsValid(ply) or not IsValid(ragdoll) then return end
+            if not ragdoll.deadringer_ragdoll then return end
+
+            if ragdoll.was_role == roles.GetByName('fake').index then
+                return false
+            end
+        end)
+
+        hook.Add('TTTBodyFound', 'DR.TTTBodyFound', function(ply, victim, ragdoll)
+            -- We have to manually confirm the body if the ragdoll is a Dead Ringer ragdoll
+            -- because TTT2 checks if the victim is alive and cloaked player is still alive
+
+            if not IsValid(ply) or not IsValid(victim) or not IsValid(ragdoll) then return end
+            if not ragdoll.deadringer_ragdoll then return end
+
+            local corpseConfirm = GetConVar('ttt_deadringer_corpse_confirm'):GetBool()
+            if not corpseConfirm or ply:TTT2NETGetBool('body_found', false) then return end
+
+            victim:ConfirmPlayer(true)
+        end)
+    end
+
+    hook.Add('TTTScoreGroup', 'DR.TTTScoreGroup', function(ply)
+        if not IsValid(ply) then return end
+
+        if ply:GetNWBool('DRCloaked', false) then
+            if TTT2 then
+                return ply:TTT2NETGetBool('body_found', false) and GROUP_FOUND or nil
+            end
+
+            return ply:GetNWBool('body_found', false) and GROUP_FOUND or nil
+        end
+    end)
+
+    hook.Add('TTTPrepareRound', 'DR.TTTPrepareRound', function()
+        for k, v in ipairs(player.GetAll()) do
+            if SERVER then
+                v:SetNWBool('DRCloaked', false)
+                v:SetNWInt('DRRole', -1)
+            end
+
+            if CLIENT then
+                v.NoTarget = Either(v.DRNoTarget == -1, nil, v.DRNoTarget == 1)
+            end
+        end
+    end)
+
+    if TTT2 then
+        hook.Add('TTTScoreboardRowColorForPlayer', 'DR.TTTScoreboardRowColorForPlayer', function(ply)
+            if not IsValid(ply) then return end
+
+            if ply:GetNWBool('DRCloaked', false) and ply:TTT2NETGetBool('body_found', false) then
+                local role = ply:GetNWInt('DRRole', -1)
+                if role == -1 then return end
+
+                local roleData = roles.GetByIndex(role)
+                if not roleData then return end
+
+                return roleData.color
+            end
+        end)
+    else
+        hook.Add('TTTScoreboardColorForPlayer', 'DR.TTTScoreboardColorForPlayer', function(ply)
+            if not IsValid(ply) then return end
+
+            if ply:GetNWBool('DRCloaked', false) and ply:GetNWBool('body_found') then
+                local role = ply:GetNWInt('DRRole', -1)
+                if role == -1 then return end
+
+                if role == ROLE_INNOCENT then
+                    return Color(0, 0, 0, 0)
+                elseif role == ROLE_TRAITOR then
+                    return Color(255, 0, 0, 30)
+                elseif role == ROLE_DETECTIVE then
+                    return Color(0, 0, 255, 30)
+                elseif ConVarExists('ttt_vote') then
+                    local roleData = GetRoleTableByID(role).DefaultColor
+
+                    return Color(roleData.r, roleData.g, roleData.b, 70)
+                end
+            end
+        end)
+    end
+end)

--- a/lua/autorun/ttt_deadringer_lang.lua
+++ b/lua/autorun/ttt_deadringer_lang.lua
@@ -1,0 +1,13 @@
+AddCSLuaFile()
+
+if CLIENT then
+	hook.Add('InitPostEntity', 'DR.InitPostEntity.English', function()
+		if LANG == nil or TTT2 then return end
+
+		LANG.AddToLanguage('english', 'deadringer_name', 'Dead Ringer')
+		LANG.AddToLanguage('english', 'deadringer_desc', 'A watch that feigns your death when you take damage. You will be cloaked for a short time and your attacker will be fooled.')
+
+		LANG.AddToLanguage('english', 'deadringer_primary', 'Activate')
+		LANG.AddToLanguage('english', 'deadringer_secondary', 'Deactivate')
+	end)
+end

--- a/lua/autorun/ttt_deadringer_ulx.lua
+++ b/lua/autorun/ttt_deadringer_ulx.lua
@@ -1,0 +1,107 @@
+AddCSLuaFile()
+
+hook.Add('Initialize', 'DR.Initialize.Ulx', function()
+    -- TTT ULX Compatibility
+    if CLIENT and not TTT2 then
+        hook.Add('TTTUlxModifyAddonSettings', 'DeadringerTTTUlxModifyAddonSettings', function(panel)
+            local root = xlib.makelistlayout{w = 415, h = 318, parent = xgui.null}
+
+            -- Basic Settings
+            local basicCategory = vgui.Create('DCollapsibleCategory', root)
+            basicCategory:SetSize(390, 50)
+            basicCategory:SetExpanded(1)
+            basicCategory:SetLabel('Basic Settings')
+
+            local basicList = vgui.Create('DPanelList', basicCategory)
+            basicList:SetPos(5, 25)
+            basicList:SetSize(390, 150)
+            basicList:SetSpacing(5)
+
+            local chargeTime = xlib.makeslider{label = 'Cloak Cooldown (def. 10)', repconvar = 'rep_ttt_deadringer_cloak_cooldown', min = 1, max = 60, decimal = 0, parent = basicList}
+            basicList:AddItem(chargeTime)
+
+            -- Cloak Settings
+            local cloakCategory = vgui.Create('DCollapsibleCategory', root)
+            cloakCategory:SetSize(390, 50)
+            cloakCategory:SetExpanded(1)
+            cloakCategory:SetLabel('Cloak Settings')
+
+            local cloakList = vgui.Create('DPanelList', cloakCategory)
+            cloakList:SetPos(5, 25)
+            cloakList:SetSize(390, 150)
+            cloakList:SetSpacing(5)
+
+            local cloakTime = xlib.makeslider{label = 'Cloak Duration (def. 6)', repconvar = 'rep_ttt_deadringer_cloak_duration', min = 1, max = 60, decimal = 0, parent = basicList}
+            cloakList:AddItem(cloakTime)
+
+            local cloakTimeReuse = xlib.makecheckbox{label = 'Cloak Time Reuse (def. 1)', repconvar = 'rep_ttt_deadringer_cloak_reuse', parent = cloakList}
+            cloakList:AddItem(cloakTimeReuse)
+
+            local cloakTransparency = xlib.makeslider{label = 'Cloak Transparency (def. 0)', repconvar = 'rep_ttt_deadringer_cloak_transparency', min = 0, max = 1, decimal = 2, parent = cloakList}
+            cloakList:AddItem(cloakTransparency)
+
+            local cloakTargetid = xlib.makecheckbox{label = 'Cloak TargetID (def. 1)', repconvar = 'rep_ttt_deadringer_cloak_targetid', parent = cloakList}
+            cloakList:AddItem(cloakTargetid)
+
+            -- Damage Reduction Settings
+            local damageCategory = vgui.Create('DCollapsibleCategory', root)
+            damageCategory:SetSize(390, 50)
+            damageCategory:SetExpanded(1)
+            damageCategory:SetLabel('Damage Reduction Settings')
+
+            local damageList = vgui.Create('DPanelList', damageCategory)
+            damageList:SetPos(5, 25)
+            damageList:SetSize(390, 150)
+            damageList:SetSpacing(5)
+
+            -- The threshold is a flat value, not a percentage
+            local damageThreshold = xlib.makeslider{label = 'Damage Threshold (def. 2)', repconvar = 'rep_ttt_deadringer_damage_threshold', min = 0, max = 100, decimal = 0, parent = damageList}
+            damageList:AddItem(damageThreshold)
+
+            local damageReduction = xlib.makeslider{label = 'Damage Reduction (def. 0.65)', repconvar = 'rep_ttt_deadringer_damage_reduction', min = 0, max = 1, decimal = 2, parent = damageList}
+            damageList:AddItem(damageReduction)
+
+            local damageReductionTime = xlib.makeslider{label = 'Damage Reduction Time (def. 3)', repconvar = 'rep_ttt_deadringer_damage_reduction_time', min = 0, max = 60, decimal = 1, parent = damageList}
+            damageList:AddItem(damageReductionTime)
+
+            local damageReductionInitial = xlib.makeslider{label = 'Damage Reduction Initial (def. 0.75)', repconvar = 'rep_ttt_deadringer_damage_reduction_initial', min = 0, max = 1, decimal = 2, parent = damageList}
+            damageList:AddItem(damageReductionInitial)
+
+            -- Corpse Settings
+            local corpseCategory = vgui.Create('DCollapsibleCategory', root)
+            corpseCategory:SetSize(390, 50)
+            corpseCategory:SetExpanded(1)
+            corpseCategory:SetLabel('Corpse Settings')
+
+            local corpseList = vgui.Create('DPanelList', corpseCategory)
+            corpseList:SetPos(5, 25)
+            corpseList:SetSize(390, 150)
+            corpseList:SetSpacing(5)
+
+            local corpseRole = xlib.makeslider{label = 'Corpse Mode (def. 0)', repconvar = 'rep_ttt_deadringer_corpse_mode', min = 0, max = 2, decimal = 0, parent = corpseList}
+            corpseList:AddItem(corpseRole)
+
+            local corpseConfirm = xlib.makecheckbox{label = 'Corpse Confirm (def. 0)', repconvar = 'rep_ttt_deadringer_corpse_confirm', parent = corpseList}
+            corpseList:AddItem(corpseConfirm)
+
+            xgui.hookEvent('onProcessModules', nil, root.processModules)
+            xgui.addSubModule('Dead Ringer', root, nil, panel)
+        end)
+    end
+
+    if SERVER and not TTT2 then
+        hook.Add('TTTUlxInitCustomCVar', 'DeadringerTTTUlxInitCustomCVar', function(name)
+            ULib.replicatedWritableCvar('ttt_deadringer_cloak_cooldown', 'rep_ttt_deadringer_cloak_cooldown', GetConVar('ttt_deadringer_cloak_cooldown'):GetFloat(), true, false, name)
+            ULib.replicatedWritableCvar('ttt_deadringer_cloak_duration', 'rep_ttt_deadringer_cloak_duration', GetConVar('ttt_deadringer_cloak_duration'):GetFloat(), true, false, name)
+            ULib.replicatedWritableCvar('ttt_deadringer_cloak_reuse', 'rep_ttt_deadringer_cloak_reuse', GetConVar('ttt_deadringer_cloak_reuse'):GetBool(), true, false, name)
+            ULib.replicatedWritableCvar('ttt_deadringer_cloak_transparency', 'rep_ttt_deadringer_cloak_transparency', GetConVar('ttt_deadringer_cloak_transparency'):GetFloat(), true, false, name)
+            ULib.replicatedWritableCvar('ttt_deadringer_cloak_targetid', 'rep_ttt_deadringer_cloak_targetid', GetConVar('ttt_deadringer_cloak_targetid'):GetBool(), true, false, name)
+            ULib.replicatedWritableCvar('ttt_deadringer_damage_threshold', 'rep_ttt_deadringer_damage_threshold', GetConVar('ttt_deadringer_damage_threshold'):GetFloat(), true, false, name)
+            ULib.replicatedWritableCvar('ttt_deadringer_damage_reduction', 'rep_ttt_deadringer_damage_reduction', GetConVar('ttt_deadringer_damage_reduction'):GetFloat(), true, false, name)
+            ULib.replicatedWritableCvar('ttt_deadringer_damage_reduction_time', 'rep_ttt_deadringer_damage_reduction_time', GetConVar('ttt_deadringer_damage_reduction_time'):GetFloat(), true, false, name)
+            ULib.replicatedWritableCvar('ttt_deadringer_damage_reduction_initial', 'rep_ttt_deadringer_damage_reduction_initial', GetConVar('ttt_deadringer_damage_reduction_initial'):GetFloat(), true, false, name)
+            ULib.replicatedWritableCvar('ttt_deadringer_corpse_mode', 'rep_ttt_deadringer_corpse_mode', GetConVar('ttt_deadringer_corpse_mode'):GetInt(), true, false, name)
+            ULib.replicatedWritableCvar('ttt_deadringer_corpse_confirm', 'rep_ttt_deadringer_corpse_confirm', GetConVar('ttt_deadringer_corpse_confirm'):GetBool(), true, false, name)
+        end)
+    end
+end)

--- a/lua/terrortown/lang/en/deadringer.lua
+++ b/lua/terrortown/lang/en/deadringer.lua
@@ -1,0 +1,40 @@
+local L = LANG.GetLanguageTableReference('en')
+
+L.deadringer_name = 'Dead Ringer'
+L.deadringer_desc = 'A device that fakes your death when you take damage, giving you a chance to escape.'
+
+L.deadringer_primary = 'Activate'
+L.deadringer_secondary = 'Deactivate'
+
+L.label_deadringer_cloak_cooldown = 'Cloak Cooldown'
+L.help_deadringer_cloak_cooldown = 'The time you have to wait before you can use the Dead Ringer again.'
+
+L.label_deadringer_cloak_duration = 'Cloak Duration'
+L.help_deadringer_cloak_duration = 'The time you are invisible after using the Dead Ringer.'
+
+L.label_deadringer_cloak_reuse = 'Cloak Reuse'
+L.help_deadringer_cloak_reuse = 'Whether or not the Dead Ringer will convert unused cloak time into cooldown reduction.'
+
+L.label_deadringer_cloak_transparency = 'Cloak Transparency'
+L.help_deadringer_cloak_transparency = 'The transparency of the player while cloaked.'
+
+L.label_deadringer_cloak_targetid = 'Cloak Target ID'
+L.help_deadringer_cloak_targetid = 'Whether or not the Dead Ringer will show/hide the target ID while cloaked.'
+
+L.label_deadringer_damage_reduction = 'Damage Reduction'
+L.help_deadringer_damage_reduction = 'The percentage of damage you take while cloaked.'
+
+L.label_deadringer_damage_threshold = 'Damage Threshold'
+L.help_deadringer_damage_threshold = 'The amount of damage you need to take in a single hit to trigger the Dead Ringer.'
+
+L.label_deadringer_damage_reduction_initial = 'Initial Damage Reduction'
+L.help_deadringer_damage_reduction_initial = 'The percentage of damage you receive when the Dead Ringer is triggered.'
+
+L.label_deadringer_damage_reduction_time = 'Damage Reduction Time'
+L.help_deadringer_damage_reduction_time = 'The time you receive reduced damage after the Dead Ringer is triggered.'
+
+L.label_deadringer_corpse_mode = 'Corpse Mode'
+L.help_deadringer_corpse_mode = 'Whether or not the Dead Ringer will show the real role of the player on the corpse. (0 = fake, 1 = real, 2 = innocent)'
+
+L.label_deadringer_corpse_confirm = 'Corpse Confirm'
+L.help_deadringer_corpse_confirm = 'Whether or not the Dead Ringer will confirm the death of the player on the corpse.'


### PR DESCRIPTION
### Fixed
- Fixed a player's role being forcibly set when being confirmed
- Fixed weapon think code not being called on clients for listen servers
- Fixed several hooks not being registered properly by ensuring they are registered after the gamemode has loaded

### Added
- Added `ttt_deadringer_cloak_transparency`
    - You can change how transparent the Dead Ringer cloak is for balance reasons (0.0 - 1.0)
    - By default it is completely transparent (0.0), if you want some subtle balance I recommend a setting of 0.05
- Added `ttt_deadringer_cloak_targetid`
    - By default the target id of the player will be hidden (setting of `0`) so you can't immediately follow where they are
    - You can set this to `1` if you want to be able to see the player's name when hovering over them still
- Added `ttt_deadringer_damage_threshold`
    - Previously the threshold to trigger the Dead Ringer was 2 damage, this is now a setting you can change

### Changed
- Renamed `ttt_deadringer_chargetime` to `ttt_deadringer_cloak_cooldown` to be more consistent with the new transparency convar
- Renamed `ttt_deadringer_cloaktime` to `ttt_deadringer_cloak_duration` to be more consistent with other convars
- Renamed `ttt_deadringer_cloaktime_reuse` to `ttt_deadringer_cloak_reuse` to be more consistent with other convars