### PR TITLE
Added ttt_deadringer_cloak_attack convar

### DIFF
--- a/lua/autorun/ttt_deadringer.lua
+++ b/lua/autorun/ttt_deadringer.lua
@@ -48,6 +48,7 @@ CreateConVar('ttt_deadringer_cloak_reuse', '0', flags, 'Whether or not the Dead 
 CreateConVar('ttt_deadringer_cloak_transparency', '0.0', flags, 'Transparency of the Dead Ringer cloak. (0.0 = invisible, 1.0 = visible)')
 CreateConVar('ttt_deadringer_cloak_targetid', '0', flags, 'Whether or not the Dead Ringer will show the target ID while cloaked.')
 CreateConVar('ttt_deadringer_cloak_reactivate', '0', flags, 'Whether or not the Dead Ringer will automatically reactivate after recharging.')
+CreateConVar('ttt_deadringer_cloak_attack', '1', flags, 'Whether or not the Dead Ringer will allow you to attack while cloaked.')
 
 CreateConVar('ttt_deadringer_damage_threshold', '2', flags, 'Threshold to trigger the Dead Ringer. The threshold is a flat value, not a percentage')
 CreateConVar('ttt_deadringer_damage_reduction', '0.65', flags, 'Damage reduction while cloaked.')

--- a/lua/weapons/weapon_ttt_deadringer.lua
+++ b/lua/weapons/weapon_ttt_deadringer.lua
@@ -92,6 +92,7 @@ function SWEP:Initialize()
     self.CVarCloakTransparency = GetConVar('ttt_deadringer_cloak_transparency')
     self.CVarCloakTargetid = GetConVar('ttt_deadringer_cloak_targetid')
     self.CVarCloakReactivate = GetConVar('ttt_deadringer_cloak_reactivate')
+    self.CVarCloakAttack = GetConVar('ttt_deadringer_cloak_attack')
 
     self.CVarDamageThreshold = GetConVar('ttt_deadringer_damage_threshold')
     self.CVarDamageReduction = GetConVar('ttt_deadringer_damage_reduction')
@@ -346,7 +347,7 @@ function SWEP:Think()
                 end
             end
 
-            if chargeTime < CurTime() then
+            if chargeTime < CurTime() or (not self.CVarCloakAttack:GetBool() and (owner:KeyDown(IN_ATTACK) or owner:KeyDown(IN_ATTACK2))) then
                 self:Uncloak(owner)
              end
         end
@@ -700,7 +701,8 @@ else
         local sound = net.ReadString()
         if not IsValid(wep) then return end
 
-        wep:EmitSound(sound, 100, 100, 1, CHAN_WEAPON)
+        -- Use CHAN_STATIC not CHAN_WEAPON, else uncloak sound will be overriden by a player's shooting sound when shooting to uncloak
+        wep:EmitSound(sound, 100, 100, 1, CHAN_STATIC)
     end)
 end
 


### PR DESCRIPTION
I didn't add anything to the changelog.

Note that you'll now need to add this convar to the list of convars you need for the dead ringer to work like the original version, so the list you added to the mod description on the Steam workshop now becomes:
ttt_deadringer_cloak_reactivate 1
ttt_deadringer_sound_activate_local 0
ttt_deadringer_sound_deactivate_local 0
ttt_deadringer_cloak_attack 0